### PR TITLE
Recording rework

### DIFF
--- a/imswitch/imcommon/framework/__init__.py
+++ b/imswitch/imcommon/framework/__init__.py
@@ -1,1 +1,2 @@
 from .qt import *
+from .napari import *

--- a/imswitch/imcommon/framework/napari.py
+++ b/imswitch/imcommon/framework/napari.py
@@ -1,0 +1,1 @@
+from napari.qt.threading import create_worker, WorkerBaseSignals, WorkerBase, FunctionWorker

--- a/imswitch/imcontrol/model/configfiletools.py
+++ b/imswitch/imcontrol/model/configfiletools.py
@@ -51,6 +51,8 @@ dirtools.initUserFilesIfNeeded()
 _setupFilesDir = os.path.join(dirtools.UserFileDirs.Root, 'imcontrol_setups')
 os.makedirs(_setupFilesDir, exist_ok=True)
 _optionsFilePath = os.path.join(dirtools.UserFileDirs.Config, 'imcontrol_options.json')
+_debugLogDir = os.path.join(dirtools.UserFileDirs.Root, 'imcontrol_debug_logs')
+os.makedirs(_debugLogDir, exist_ok=True)
 
 _options = None
 

--- a/imswitch/imcontrol/model/managers/RecordingManager.py
+++ b/imswitch/imcontrol/model/managers/RecordingManager.py
@@ -355,6 +355,45 @@ class TiffStorer(Storer):
             description = omexml.tostring(declaration=True)
             file.overwrite_description(description.encode())
 
+class BytesIOStorer(Storer):
+    """Storer class for local RAM data. Uses BytesIO to stream images from detectors
+    to local memory buffer.
+    """    
+    def stream(self, channel: str, recMode: RecMode, attrs: Dict[str, str], **kwargs) -> None:
+        # TODO: parse metadata... does it make sense?
+        # TODO: add storage of frame ID
+        memRecording: BytesIO = kwargs["fileDests"][channel]
+        detector: DetectorManager = self.detectorsManager[channel]
+        
+        self.record = True
+        if recMode == RecMode.SpecFrames:
+            if recMode == RecMode.SpecFrames:
+                totalFrames = kwargs["totalFrames"]
+                while self.frameCount < totalFrames and self.record:
+                    frames, _ = self.unpackChunk(detector)
+                    if self.frameCount + len(frames) >= totalFrames:
+                        # we only collect the remaining frames required,
+                        # and discard the remaining
+                        frames = frames[0: totalFrames - self.frameCount]
+                    memRecording.write(frames)
+                    self.frameCount += len(frames)
+                    self.frameNumberUpdate.emit(channel, self.frameCount)
+                return
+            elif recMode == RecMode.SpecTime:
+                totalTime = kwargs["totalTime"]
+                currentRecTime = 0
+                start = time.time()
+                while currentRecTime < totalTime and self.record:
+                    frames, _ = self.unpackChunk(detector)
+                    memRecording.write(frames)
+                    self.timeCount = np.around(currentRecTime, decimals=2)
+                    self.timeUpdate.emit(channel, self.timeCount)
+                    currentRecTime = time.time() - start
+            elif recMode == RecMode.UntilStop:
+                while self.record:
+                    frames, _ = self.unpackChunk(detector)
+                    memRecording.write(frames)
+
 DEFAULT_STORER_MAP: Dict[str, Type[Storer]] = {
     SaveFormat.ZARR: ZarrStorer,
     SaveFormat.HDF5: HDF5Storer,

--- a/imswitch/imcontrol/model/managers/RecordingManager.py
+++ b/imswitch/imcontrol/model/managers/RecordingManager.py
@@ -27,6 +27,18 @@ class RecMode(enum.Enum):
     ScanLapse = 4
     UntilStop = 5
 
+class SaveMode(enum.Enum):
+    Disk = 1
+    RAM = 2
+    DiskAndRAM = 3
+    Numpy = 4
+
+
+class SaveFormat(enum.Enum):
+    HDF5 = 1
+    TIFF = 2
+    ZARR = 3
+
 class AsTemporayFile(object):
     """ A temporary file that when exiting the context manager is renamed to its original name. """
     def __init__(self, filepath, tmp_extension='.tmp'):
@@ -112,20 +124,6 @@ class TiffStorer(Storer):
             with AsTemporayFile(f'{self.filepath}_{channel}.tiff') as path:
                 tiff.imwrite(path, image,) # TODO: Parse metadata to tiff meta data
                 logger.info(f"Saved image to tiff file {path}")
-
-
-class SaveMode(enum.Enum):
-    Disk = 1
-    RAM = 2
-    DiskAndRAM = 3
-    Numpy = 4
-
-
-class SaveFormat(enum.Enum):
-    HDF5 = 1
-    TIFF = 2
-    ZARR = 3
-
 
 DEFAULT_STORER_MAP: Dict[str, Type[Storer]] = {
     SaveFormat.ZARR: ZarrStorer,

--- a/imswitch/imcontrol/model/managers/RecordingManager.py
+++ b/imswitch/imcontrol/model/managers/RecordingManager.py
@@ -3,6 +3,7 @@ import os
 import time
 from io import BytesIO
 from typing import Dict, Optional, Type, List
+from types import DynamicClassAttribute
 
 import h5py
 import zarr
@@ -38,6 +39,13 @@ class SaveFormat(enum.Enum):
     HDF5 = 1
     TIFF = 2
     ZARR = 3
+
+    @DynamicClassAttribute
+    def name(self):
+        name = super(SaveFormat, self).name
+        if name == "TIFF":
+            name = "OME-TIFF"
+        return name
 
 class AsTemporayFile(object):
     """ A temporary file that when exiting the context manager is renamed to its original name. """

--- a/imswitch/imcontrol/model/managers/RecordingManager.py
+++ b/imswitch/imcontrol/model/managers/RecordingManager.py
@@ -20,6 +20,12 @@ from imswitch.imcontrol.model.managers.DetectorsManager import DetectorsManager
 
 logger = logging.getLogger(__name__)
 
+class RecMode(enum.Enum):
+    SpecFrames = 1
+    SpecTime = 2
+    ScanOnce = 3
+    ScanLapse = 4
+    UntilStop = 5
 
 class AsTemporayFile(object):
     """ A temporary file that when exiting the context manager is renamed to its original name. """
@@ -34,7 +40,6 @@ class AsTemporayFile(object):
 
     def __exit__(self, *args, **kwargs):
         os.rename(self.tmp_path, self.path)
-
 
 class Storer(abc.ABC):
     """ Base class for storing data"""
@@ -615,14 +620,6 @@ class RecordingWorker(Worker):
         newFrames = self.__recordingManager.detectorsManager[detectorName].getChunk()
         newFrames = np.array(newFrames)
         return newFrames
-
-
-class RecMode(enum.Enum):
-    SpecFrames = 1
-    SpecTime = 2
-    ScanOnce = 3
-    ScanLapse = 4
-    UntilStop = 5
 
 
 # Copyright (C) 2020-2021 ImSwitch developers

--- a/imswitch/imcontrol/model/managers/RecordingManager.py
+++ b/imswitch/imcontrol/model/managers/RecordingManager.py
@@ -91,7 +91,7 @@ class Storer(SignalInterface):
         """ Stores data in a streaming fashion. """
         raise NotImplementedError
     
-    def unpackChunk(self, channel: str) -> Tuple[np.ndarray, np.ndarray]:
+    def unpackChunk(self, detectorManager: DetectorManager) -> Tuple[np.ndarray, np.ndarray]:
         """ Checks if the value returned by getChunk is a tuple (packing the recorded chunk and the associated time points).
         If the return type is only the recorded stack, a zero array is generated with the same length of 
         the recorded chunk.
@@ -102,7 +102,7 @@ class Storer(SignalInterface):
         Returns:
             tuple: a 2-element tuple with the recorded chunk and the single data points associated with each frame.
         """
-        chunk = self.detectorsManager[channel].getChunk()
+        chunk = detectorManager.getChunk()
         if type(chunk) == tuple:
             return chunk
         else: # type is np.ndarray

--- a/imswitch/imcontrol/model/managers/detectors/DetectorManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/DetectorManager.py
@@ -111,6 +111,10 @@ class DetectorManager(SignalInterface):
 
         self.setBinning(supportedBinnings[0])
 
+        self._imageProcessing = {}
+        self._dtype = np.uint16
+        self._frameInterval = 1000.0 # us
+
     def updateLatestFrame(self, init):
         """ :meta private: """
         try:
@@ -205,6 +209,22 @@ class DetectorManager(SignalInterface):
     def forFocusLock(self) -> bool:
         """ Whether the detector is used for focus lock. """
         return self.__forFocusLock
+
+    @property
+    def imageProcessing(self) -> dict:
+        """ Returns the dictionary of image processing objects in the detector. """
+        return self._imageProcessing
+    
+    @property
+    def dtype(self) -> Any:
+        """ Returns the image numpy data type for correct recording storage. """
+        return self._dtype
+    
+    @property
+    def frameInterval(self) -> Tuple[float]:
+        """ The time interval between each frame, specified in microseconds.
+        """
+        return self._frameInterval
 
     @property
     def scale(self) -> List[int]:

--- a/imswitch/imcontrol/model/managers/detectors/DetectorManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/DetectorManager.py
@@ -1,7 +1,7 @@
 import traceback
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -233,11 +233,13 @@ class DetectorManager(SignalInterface):
         pass
 
     @abstractmethod
-    def getChunk(self) -> np.ndarray:
+    def getChunk(self) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """ Returns the frames captured by the detector since getChunk was last
         called, or since the buffers were last flushed (whichever happened
-        last). The returned object is a numpy array of shape
-        (numFrames, height, width). """
+        last). Depending on the detector, the returned object can be:
+        - a numpy array of shape (numFrames, height, width); 
+        - a tuple of two numpy arrays: the first of shape (numFrames, height, width),
+            and the second of shape (numFrames,). The second array contains the frame IDs"""
         pass
 
     @abstractmethod


### PR DESCRIPTION
An attempt to rework the `RecordingManager`, also mentioned in #171:

- added the napari threading infrastructure to the basic framework
- changed the `Storer` base class from `abc.ABC` to `SignalInterface`
  - this gives the possibility to send Qt signals to the GUI to update on the current recording status
- added `stream` method to `HDF5Storer` and `TiffStorer`
- added `BytesIOStorer` class to keep the possibility to store data in RAM for reconstruction
  - this is still untested
- full rework of the `RecordingManager`
  - for each detector, a `StreamingWorker` thread, which is a napari wrapper over the `QRunnable` class, is spawned
  - a storer object is created and associated to each thread
  - acquisition loops are called within the threads
  - NOTE: timelapse acquisition is currently **NOT** supported